### PR TITLE
Add search links for scummvm and dosbox

### DIFF
--- a/GBM_Official.xsl
+++ b/GBM_Official.xsl
@@ -90,10 +90,16 @@
                                 <img class="logo_tiny" src="images/retail_logo_tiny.png" width="24" height="24" alt="Retail" title="Retail" />
                               </xsl:if>
                               <xsl:if test="Name='DOSBox'">
-                                <img class="logo_tiny" src="images/dosbox_logo_tiny.png" width="24" height="24" alt="DOSBox" title="DOSBox" />
+                                <a>
+                                  <xsl:attribute name="href">https://www.dosbox.com/comp_list.php?search=<xsl:value-of select="../../Name"/></xsl:attribute>
+                                  <img class="logo_tiny" src="images/dosbox_logo_tiny.png" width="24" height="24" alt="DOSBox" title="DOSBox" />
+                                </a>
                               </xsl:if>
                               <xsl:if test="Name='ScummVM'">
-                                <img class="logo_tiny" src="images/scumm_logo_tiny.png" width="24" height="24" alt="ScummVM" title="ScummVM" />
+                                <a>
+                                  <xsl:attribute name="href">http://wiki.scummvm.org/index.php?search=<xsl:value-of select="../../Name"/></xsl:attribute>
+                                  <img class="logo_tiny" src="images/scumm_logo_tiny.png" width="24" height="24" alt="ScummVM" title="ScummVM" />
+                                </a>
                               </xsl:if>
                               <xsl:if test="Name='FLOSS'">
                                 <img class="logo_tiny" src="images/floss_logo_tiny.png" width="24" height="24" alt="FLOSS" title="FLOSS" />

--- a/GBM_Official_Linux.xsl
+++ b/GBM_Official_Linux.xsl
@@ -90,10 +90,16 @@
                                 <img class="logo_tiny" src="images/retail_logo_tiny.png" width="24" height="24" alt="Retail" title="Retail" />
                               </xsl:if>
                               <xsl:if test="Name='DOSBox'">
-                                <img class="logo_tiny" src="images/dosbox_logo_tiny.png" width="24" height="24" alt="DOSBox" title="DOSBox" />
+                                <a>
+                                  <xsl:attribute name="href">https://www.dosbox.com/comp_list.php?search=<xsl:value-of select="../../Name"/></xsl:attribute>
+                                  <img class="logo_tiny" src="images/dosbox_logo_tiny.png" width="24" height="24" alt="DOSBox" title="DOSBox" />
+                                </a>
                               </xsl:if>
                               <xsl:if test="Name='ScummVM'">
-                                <img class="logo_tiny" src="images/scumm_logo_tiny.png" width="24" height="24" alt="ScummVM" title="ScummVM" />
+                                <a>
+                                  <xsl:attribute name="href">http://wiki.scummvm.org/index.php?search=<xsl:value-of select="../../Name"/></xsl:attribute>
+                                  <img class="logo_tiny" src="images/scumm_logo_tiny.png" width="24" height="24" alt="ScummVM" title="ScummVM" />
+                                </a>
                               </xsl:if>
                               <xsl:if test="Name='FLOSS'">
                                 <img class="logo_tiny" src="images/floss_logo_tiny.png" width="24" height="24" alt="FLOSS" title="FLOSS" />


### PR DESCRIPTION
ScummVM wiki and DOSBox compatibility list.

The compatibility list of ScummVM has no search and the wiki pages don’t list the support level. They can help to find out where to get the game, though.